### PR TITLE
get dagster-mlflow passing dagster build

### DIFF
--- a/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
+++ b/.buildkite/dagster-buildkite/dagster_buildkite/steps/dagster.py
@@ -378,6 +378,7 @@ DAGSTER_PACKAGES_WITH_CUSTOM_TESTS = [
         extra_cmds_fn=k8s_extra_cmds_fn,
         depends_on_fn=test_image_depends_fn,
     ),
+    ModuleBuildSpec("python_modules/libraries/dagster-mlflow", upload_coverage=False),
     ModuleBuildSpec("python_modules/libraries/dagster-mysql", extra_cmds_fn=mysql_extra_cmds_fn),
     ModuleBuildSpec(
         "python_modules/libraries/dagster-postgres", extra_cmds_fn=postgres_extra_cmds_fn

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/__init__.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/__init__.py
@@ -1,8 +1,9 @@
 from dagster.core.utils import check_dagster_package_version
 
-from .resources import mlflow_tracking, cleanup_on_success, cleanup_on_dagit_failure
+from .hooks import end_mlflow_run_on_pipeline_finished
+from .resources import mlflow_tracking
 from .version import __version__
 
 check_dagster_package_version("dagster-mlflow", __version__)
 
-__all__ = ["mlflow_tracking", "cleanup_on_success", "cleanup_on_dagit_failure"]
+__all__ = ["mlflow_tracking", "end_mlflow_run_on_pipeline_finished"]

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/hooks.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/hooks.py
@@ -1,0 +1,25 @@
+from dagster.core.definitions.decorators.hook import event_list_hook
+from mlflow.entities.run_status import RunStatus
+
+
+@event_list_hook(required_resource_keys={"mlflow"})
+def end_mlflow_run_on_pipeline_finished(context, event_list):
+    for event in event_list:
+        if event.is_step_success:
+            _cleanup_on_success(context)
+        elif event.is_step_failure:
+            mlf = context.resources.mlflow
+            mlf.end_run(status=RunStatus.to_string(RunStatus.FAILED))
+
+
+def _cleanup_on_success(context):
+    """
+    Checks if the current solid in the context is the last solid in the pipeline
+    and ends the mlflow run with a successful status when this is the case.
+    """
+    last_solid_name = context._step_execution_context.pipeline_def.solids_in_topological_order[  # pylint: disable=protected-access
+        -1
+    ].name
+
+    if context.solid.name == last_solid_name:
+        context.resources.mlflow.end_run()

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow/resources.py
@@ -247,7 +247,7 @@ def mlflow_tracking(context):
             @solid(required_resource_keys={"mlflow"})
             def mlflow_solid(context):
                 mlflow.log_params(some_params)
-                mlflow.tracking_client.create_registered_model(some_model_name)
+                mlflow.tracking.MlflowClient().create_registered_model(some_model_name)
 
             @end_mlflow_run_on_pipeline_finished
             @pipeline(mode_defs=[ModeDefinition(resource_defs={"mlflow": mlflow_tracking})])

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_hooks.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_hooks.py
@@ -1,0 +1,34 @@
+from unittest.mock import Mock
+
+from dagster_mlflow.hooks import _cleanup_on_success
+
+
+def test_cleanup_on_success():
+
+    # Given: - two mock solids
+    mock_solid_1 = Mock(name="solid_1")
+    mock_solid_2 = Mock(name="solid_2")
+
+    # - a mock context containing a list of these two solids and a current solid
+    mock_context = Mock()
+    step_execution_context = (
+        mock_context._step_execution_context  # pylint: disable=protected-access
+    )
+    step_execution_context.pipeline_def.solids_in_topological_order = [
+        mock_solid_1,
+        mock_solid_2,
+    ]
+    mock_context.solid = mock_solid_2
+
+    # When: the cleanup function is called with the mock context
+    _cleanup_on_success(mock_context)
+
+    # Then:
+    # - mlflow.end_run is called if solid is the last solid
+    mock_context.resources.mlflow.end_run.assert_called_once()
+
+    # - mlflow.end_run is not called when the solid in the context is not the last solid
+    mock_context.reset_mock()
+    mock_context.solid = mock_solid_1
+    _cleanup_on_success(mock_context)
+    mock_context.resources.mlflow.end_run.assert_not_called()

--- a/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
+++ b/python_modules/libraries/dagster-mlflow/dagster_mlflow_tests/test_resources.py
@@ -1,18 +1,20 @@
 """
 Unit testing the Mlflow class
 """
+# pylint: disable=redefined-outer-name
 import logging
 import random
 import string
 import uuid
 from copy import deepcopy
 from typing import Any, Dict
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import mlflow
 import pandas as pd
 import pytest
-from dagster_mlflow.resources import MlFlow, _cleanup_on_success
+from dagster import ModeDefinition, execute_pipeline, pipeline, solid
+from dagster_mlflow.resources import MlFlow, mlflow_tracking
 
 
 @pytest.fixture
@@ -88,7 +90,7 @@ def child_context(basic_context, mlflow_run_config):
 def cleanup_mlflow_runs():
     yield
     while mlflow.active_run():
-        mlflow.end_run()
+        mlflow.end_run()  # pylint: disable=no-member
 
 
 @patch("os.environ.update")
@@ -105,57 +107,57 @@ def test_mlflow_constructor_basic(
     context,
 ):
     with patch.object(MlFlow, "_setup") as mock_setup:
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
-        ## Then:
-        ## the _setup() is called once
+        # Then:
+        # the _setup() is called once
         mock_setup.assert_called_once()
-    ## - the mlflow library methods & attributes have been added to the object
+    # - the mlflow library methods & attributes have been added to the object
     assert all(hasattr(mlf, attr) for attr in dir(MlFlow) if attr not in ("__name__"))
 
-    ## - the context associated attributes passed have been set
+    # - the context associated attributes passed have been set
     assert mlf.log == context.log
     assert mlf.run_name == context.pipeline_run.pipeline_name
     assert mlf.dagster_run_id == context.run_id
 
-    ## - the tracking URI is the same as what was passed
+    # - the tracking URI is the same as what was passed
     assert mlf.tracking_uri == context.resource_config.get("mlflow_tracking_uri")
-    ## - the tracking URI was set to mlflow
+    # - the tracking URI was set to mlflow
     if mlf.tracking_uri:
         mock_set_tracking_uri.assert_called_once_with(mlf.tracking_uri)
     else:
         mock_set_tracking_uri.assert_not_called()
-    ## - the resource config attributes have been set
+    # - the resource config attributes have been set
     assert mlf.parent_run_id == context.resource_config.get("parent_run_id")
     assert mlf.experiment_name == context.resource_config.get("experiment_name")
     assert mlf.env_tags_to_log == context.resource_config.get("env_to_tag", [])
     assert mlf.extra_tags == context.resource_config.get("extra_tags")
     assert mlf.env_vars == context.resource_config.get("env", {})
 
-    ## - the env vars that have been updated are set
+    # - the env vars that have been updated are set
     if mlf.env_vars:
         mock_environ_update.assert_called_once_with(mlf.env_vars)
     else:
         mock_environ_update.assert_not_called()
     mock_set_experiment.assert_called_once_with(mlf.experiment_name)
     mock_get_experiment_by_name(mlf.experiment_name)
-    ## - mlflow.tracking.MlflowClient has been called
+    # - mlflow.tracking.MlflowClient has been called
     mock_mlflowclient.assert_called_once()
 
 
-def test_mlflow_meta_not_overloading(context):
-    ## Given an MlFlow
-    ## And: a list of overloaded mlflow methods
+def test_mlflow_meta_not_overloading():
+    # Given an MlFlow
+    # And: a list of overloaded mlflow methods
     # TODO: find a way to get this list
     over_list = ["log_params"]
     for methods in over_list:
-        ## then: the function signature is not the same as the mlflow one
+        # then: the function signature is not the same as the mlflow one
         assert getattr(MlFlow, methods) != getattr(mlflow, methods)
 
 
-def test_mlflow_meta_overloading(context):
-    ## Given an MlFlow
-    ## And: a list of inherited mlflow methods
+def test_mlflow_meta_overloading():
+    # Given an MlFlow
+    # And: a list of inherited mlflow methods
     # TODO: find a way to get this list
     inherited_list = [
         method for method in dir(mlflow) if method not in ["log_params", "__name__", "__doc__"]
@@ -169,53 +171,54 @@ def test_mlflow_meta_overloading(context):
 def test_start_run(mock_start_run, context):
 
     with patch.object(MlFlow, "_setup"):
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
 
-    ## When: a run is started
+    # When: a run is started
     run_id_1 = str(uuid.uuid4())
-    mlf._start_run(run_id=run_id_1)
-    ## Then mlflow start_run is called
+    mlf._start_run(run_id=run_id_1)  # pylint: disable=protected-access
+    # Then mlflow start_run is called
     mock_start_run.assert_called_once_with(run_id=run_id_1)
 
-    ## And when start run is called with the same run_id no excpetion is raised
-    mlf._start_run(run_id=run_id_1)
+    # And when start run is called with the same run_id no excpetion is raised
+    mlf._start_run(run_id=run_id_1)  # pylint: disable=protected-access
 
 
 @patch("mlflow.end_run")
 @pytest.mark.parametrize("any_error", [KeyboardInterrupt(), OSError(), RuntimeError(), None])
-def test_cleanup_on_error(mock_mlflow_end_run, any_error, context, cleanup_mlflow_runs):
-
+def test_cleanup_on_error(
+    mock_mlflow_end_run, any_error, context, cleanup_mlflow_runs  # pylint: disable=unused-argument
+):
     with patch.object(MlFlow, "_setup"):
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
-    ## When: a run is started
-    mlf.start_run()
+    # When: a run is started
+    mlf.start_run()  # pylint: disable=no-member
 
     with patch("sys.exc_info", return_value=[0, any_error]):
-        ## When: cleanup_on_error is called
+        # When: cleanup_on_error is called
         mlf.cleanup_on_error()
-    ## Then:
+    # Then:
     if any_error:
         if isinstance(any_error, KeyboardInterrupt):
-            ## mlflow.end_run is called with status=KILLED if KeyboardInterrupt
+            # mlflow.end_run is called with status=KILLED if KeyboardInterrupt
             mock_mlflow_end_run.assert_called_once_with(status="KILLED")
         else:
-            ## mlflow.end_run is called with status=FAILED for all other errors
+            # mlflow.end_run is called with status=FAILED for all other errors
             mock_mlflow_end_run.assert_called_once_with(status="FAILED")
         assert True
     else:
-        ## mlflow.end_run is not called when no error is flagged
+        # mlflow.end_run is not called when no error is flagged
         mock_mlflow_end_run.assert_not_called()
 
 
 @patch("mlflow.set_tags")
 def test_set_all_tags(mock_mlflow_set_tags, context):
     with patch.object(MlFlow, "_setup"):
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
-    ## When all the tags are set
-    mlf._set_all_tags()
+    # When all the tags are set
+    mlf._set_all_tags()  # pylint: disable=protected-access
 
     # Given: the tags that should be set in mlflow
     tags = {
@@ -224,7 +227,7 @@ def test_set_all_tags(mock_mlflow_set_tags, context):
     tags["dagster_run_id"] = mlf.dagster_run_id
     if mlf.extra_tags:
         tags.update(mlf.extra_tags)
-    ## Then the Mlflow.set_tags is called with the set tags
+    # Then the Mlflow.set_tags is called with the set tags
     mock_mlflow_set_tags.assert_called_once_with(tags)
 
 
@@ -233,13 +236,13 @@ def test_set_all_tags(mock_mlflow_set_tags, context):
     "experiment", [None, MagicMock(experiment_id="1"), MagicMock(experiment_id="lol")]
 )
 def test_get_current_run_id(context, experiment, run_df):
-    ## Given: an initialization of the mlflow object
+    # Given: an initialization of the mlflow object
     mlf = MlFlow(context)
 
-    with patch("mlflow.search_runs", return_value=run_df) as mock_search_runs:
-        ## when: _get_current_run_id is called
-        run_id = mlf._get_current_run_id(experiment=experiment)
-    ## Then: the run_id id provided is the same as what was provided
+    with patch("mlflow.search_runs", return_value=run_df):
+        # when: _get_current_run_id is called
+        run_id = mlf._get_current_run_id(experiment=experiment)  # pylint: disable=protected-access
+    # Then: the run_id id provided is the same as what was provided
     if not run_df.empty:
         assert run_id == run_df.run_id.values[0]
     else:
@@ -250,7 +253,7 @@ def test_get_current_run_id(context, experiment, run_df):
 def test_setup(mock_atexit, context):
 
     with patch.object(MlFlow, "_setup"):
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
 
     with patch.object(
@@ -260,117 +263,131 @@ def test_setup(mock_atexit, context):
     ) as mock_set_active_run, patch.object(
         MlFlow, "_set_all_tags"
     ) as mock_set_all_tags:
-        ## When _setup is called
-        mlf._setup()
-        ## Then
-        ## - _get_current_run_id is called once with the experiment object
+        # When _setup is called
+        mlf._setup()  # pylint: disable=protected-access
+        # Then
+        # - _get_current_run_id is called once with the experiment object
         mock_get_current_run_id.assert_called()
-        ## - _set_active_run is called once with the run_id returned from _get_current_run_id
+        # - _set_active_run is called once with the run_id returned from _get_current_run_id
         mock_set_active_run.assert_called_once_with(run_id="run_id_mock")
-        ## - _set_all_tags is called once
+        # - _set_all_tags is called once
         mock_set_all_tags.assert_called_once()
-    ## - atexit.unregister is called with mlf.end_run as an argument
-    mock_atexit.assert_called_once_with(mlf.end_run)
+    # - atexit.unregister is called with mlf.end_run as an argument
+    mock_atexit.assert_called_once_with(mlf.end_run)  # pylint: disable=no-member
 
 
 @pytest.mark.parametrize("run_id", [None, 0, "12"])
 def test_set_active_run(context, run_id):
 
     with patch.object(MlFlow, "_setup"):
-        ## Given: a context  passed into the __init__ for MlFlow
+        # Given: a context  passed into the __init__ for MlFlow
         mlf = MlFlow(context)
 
     with patch.object(MlFlow, "_start_run") as mock_start_run:
-        ## When _set_active_run is called
-        mlf._set_active_run(run_id=run_id)
+        # When _set_active_run is called
+        mlf._set_active_run(run_id=run_id)  # pylint: disable=protected-access
 
-    ## And: the run is nested
+    # And: the run is nested
     if mlf.parent_run_id is not None:
-        ## Then:
-        ## - the parent run is started if required
+        # Then:
+        # - the parent run is started if required
         mock_start_run.assert_any_call(run_id=mlf.parent_run_id, run_name=mlf.run_name)
-        ## - mlflow.start_run is called with nested=True
+        # - mlflow.start_run is called with nested=True
         mock_start_run.assert_any_call(run_id=run_id, run_name=mlf.run_name, nested=True)
-        ## - _start_run is called twice
-        mock_start_run.call_count == 2
-    ## And: the run is not nested
+        # - _start_run is called twice
+        assert mock_start_run.call_count == 2
+    # And: the run is not nested
     else:
-        ## Then:
+        # Then:
         mock_start_run.assert_called_once_with(run_id=run_id, run_name=mlf.run_name, nested=False)
 
 
 def test_set_active_run_parent_zero(child_context):
-    ## Given: a parent_run_id of zero
+    # Given: a parent_run_id of zero
     child_context.resource_config["parent_run_id"] = 0
-    ## : an initialization of the mlflow object
+    # : an initialization of the mlflow object
     mlf = MlFlow(child_context)
 
     with patch.object(MlFlow, "_start_run") as mock_start_run:
-        ## And _set_active_run is called with run_id
-        mlf._set_active_run(run_id="what-is-an-edge-case")
-        ## Then: _start_run_by_id is called with the parent_id
+        # And _set_active_run is called with run_id
+        mlf._set_active_run(run_id="what-is-an-edge-case")  # pylint: disable=protected-access
+        # Then: _start_run_by_id is called with the parent_id
         mock_start_run.assert_any_call(run_id=mlf.parent_run_id, run_name=mlf.run_name)
-        ## And: mlflow.start_run is called with the run_name and nested=True
+        # And: mlflow.start_run is called with the run_name and nested=True
         mock_start_run.assert_any_call(
             run_id="what-is-an-edge-case", run_name=mlf.run_name, nested=True
         )
-        ## And _start_run is called twice
-        mock_start_run.call_count == 2
+        # And _start_run is called twice
+        assert mock_start_run.call_count == 2
 
 
 @patch("mlflow.log_params")
 @pytest.mark.parametrize("num_of_params", (90, 101, 223))
 def test_log_params(mock_log_params, context, num_of_params, string_maker):
-    ## Given: init of MlFlow
+    # Given: init of MlFlow
     mlf = MlFlow(context)
-    ## And: a set of parameters
+    # And: a set of parameters
     param = {string_maker(5): string_maker(5) for _ in range(num_of_params)}
-    ## When: log_params is called
+    # When: log_params is called
     mlf.log_params(param)
-    ## Then mock_log_params is called the correct number of times
+    # Then mock_log_params is called the correct number of times
     assert mock_log_params.call_count == num_of_params // 100 + (1 if num_of_params % 100 else 0)
 
 
 @pytest.mark.parametrize("chunk", (10, 100))
 @pytest.mark.parametrize("num_of_params", (90, 200))
 def test_chunks(context, num_of_params, string_maker, chunk):
-    ## Given: init of MLFlow
+    # Given: init of MLFlow
     mlf = MlFlow(context)
-    ## And: a dictionary
+    # And: a dictionary
     D = {string_maker(5): string_maker(5) for _ in range(num_of_params)}
-    ## When: dictionary is chunked
+    # When: dictionary is chunked
     param_chunks_list = [param_chunk for param_chunk in mlf.chunks(D, chunk)]
 
-    ## Then
+    # Then
     # - the number of chunks is what is expected
     assert len(param_chunks_list) == num_of_params // chunk + (1 if num_of_params % chunk else 0)
     # - the unwrapped dictionary is the same as was set
     assert {k: v for d in param_chunks_list for k, v in d.items()} == D
 
 
-def test_cleanup_on_success():
+def test_execute_solid_with_mlflow_resource():
+    run_id_holder = {}
 
-    # Given: - two mock solids
-    mock_solid_1 = Mock(name="solid_1")
-    mock_solid_2 = Mock(name="solid_2")
+    params = {"learning_rate": "0.01", "n_estimators": "10"}
+    extra_tags = {"super": "experiment"}
 
-    # - a mock context containing a list of these two solids and a current solid
-    mock_context = Mock()
-    mock_context._step_execution_context.pipeline_def.solids_in_topological_order = [
-        mock_solid_1,
-        mock_solid_2,
-    ]
-    mock_context.solid = mock_solid_2
+    @solid(required_resource_keys={"mlflow"})
+    def solid1(_):
+        mlflow.log_params(params)
+        run_id_holder["solid1_run_id"] = mlflow.active_run().info.run_id
 
-    # When: the cleanup function is called with the mock context
-    _cleanup_on_success(mock_context)
+    @solid(required_resource_keys={"mlflow"})
+    def solid2(_, _arg1):
+        run_id_holder["solid2_run_id"] = mlflow.active_run().info.run_id
 
-    # Then:
-    # - mlflow.end_run is called if solid is the last solid
-    mock_context.resources.mlflow.end_run.assert_called_once()
+    @pipeline(mode_defs=[ModeDefinition(resource_defs={"mlflow": mlflow_tracking})])
+    def mlf_pipeline():
+        solid2(solid1())
 
-    # - mlflow.end_run is not called when the solid in the context is not the last solid
-    mock_context.reset_mock()
-    mock_context.solid = mock_solid_1
-    _cleanup_on_success(mock_context)
-    mock_context.resources.mlflow.end_run.assert_not_called()
+    result = execute_pipeline(
+        mlf_pipeline,
+        run_config={
+            "resources": {
+                "mlflow": {
+                    "config": {
+                        "experiment_name": "my_experiment",
+                        "extra_tags": extra_tags,
+                    }
+                }
+            }
+        },
+    )
+    assert result.success
+
+    assert run_id_holder["solid1_run_id"] == run_id_holder["solid2_run_id"]
+    run = mlflow.get_run(run_id_holder["solid1_run_id"])
+    assert run.data.params == params
+    assert set(extra_tags.items()).issubset(run.data.tags.items())
+
+    assert mlflow.get_experiment_by_name("my_experiment")

--- a/python_modules/libraries/dagster-mlflow/tox.ini
+++ b/python_modules/libraries/dagster-mlflow/tox.ini
@@ -14,7 +14,7 @@ commands =
   !windows: /bin/bash -c '! pip list --exclude-editable | grep -e dagster -e dagit'
   coverage erase
   echo -e "--- \033[0;32m:pytest: Running tox tests\033[0m"
-  pytest -vv --junitxml=test_results.xml --cov=dagster_datadog --cov-append --cov-report= {posargs}
+  pytest -vv --junitxml=test_results.xml --cov=dagster_mlflow --cov-append --cov-report= {posargs}
   coverage report --omit='.tox/*,**/test_*.py' --skip-covered
   coverage html --omit='.tox/*,**/test_*.py'
   coverage xml --omit='.tox/*,**/test_*.py'


### PR DESCRIPTION
This pull request gets dagster-mlflow passing dagster's build and implements some of the suggestions that I made in the base pull request.

The changes bundled into this pull request:
* Fixes lint complaints and import-ordering complaints.
* Consolidates the hooks into a single `end_mlflow_run_on_pipeline_finished ` hook.
* Adds a test that uses the resource inside a pipeline.
* Suggests usage of "mlflow.log_params" instead of "context.resources.mlflow.log_params".